### PR TITLE
Fix: Adicionado 'serializer_class' para a view 'EditarTreinos'

### DIFF
--- a/appTreinoBackend/treinos/views/view_treinos.py
+++ b/appTreinoBackend/treinos/views/view_treinos.py
@@ -11,3 +11,4 @@ class ListarTreinos(generics.ListCreateAPIView):
 
 class EditarTreinos(generics.RetrieveUpdateDestroyAPIView):
     queryset = Treinos.objects.all()
+    serializer_class = SerializerTreinos


### PR DESCRIPTION
### Problema

Não estava conseguindo acessar o caminho treinos/<uuid:pk>/ para visualizar um treino especifico na minha api.

### Fix

- Adicionado o `serializer_class` ao modelo `EditarTreinos`;

![image](https://github.com/user-attachments/assets/8d94bf98-9d02-4638-803c-5da0f80afff7)
